### PR TITLE
Arrays.asList returns Arrays.ArrayList which does not allow addAll

### DIFF
--- a/src/main/java/com/github/rutledgepaulv/qbuilders/builders/QBuilder.java
+++ b/src/main/java/com/github/rutledgepaulv/qbuilders/builders/QBuilder.java
@@ -99,14 +99,16 @@ public class QBuilder<T extends QBuilder<T>> implements Partial<T> {
 
     @SafeVarargs
     public final Condition<T> and(Condition<T> c1, Condition<T> c2, Condition<T>... cn) {
-        List<Condition<T>> conditions = asList(c1,c2);
+        List<Condition<T>> conditions = new ArrayList<>();
+        conditions.addAll(asList(c1,c2));
         conditions.addAll(asList(cn));
         return and(conditions);
     }
 
     @SafeVarargs
     public final Condition<T> or(Condition<T> c1, Condition<T> c2, Condition<T>... cn) {
-        List<Condition<T>> conditions = asList(c1,c2);
+        List<Condition<T>> conditions = new ArrayList<>();
+        conditions.addAll(asList(c1,c2));
         conditions.addAll(asList(cn));
         return or(conditions);
     }


### PR DESCRIPTION
Arrays.asList returns Arrays.ArrayList , not java.util.ArrayList and it throws java.lang.UnsupportedOperationException when calling addAll:
Exception in thread "main" java.lang.UnsupportedOperationException
	at java.util.AbstractList.add(AbstractList.java:148)
	at java.util.AbstractList.add(AbstractList.java:108)
	at java.util.AbstractCollection.addAll(AbstractCollection.java:344)
	at com.github.rutledgepaulv.qbuilders.builders.QBuilder.and(QBuilder.java:103)